### PR TITLE
sets default value false for kwarg vconstant introduced in 1.15

### DIFF
--- a/src/dispatch.jl
+++ b/src/dispatch.jl
@@ -342,6 +342,7 @@ function default_plot_kwargs()
         :spacing => Pair(:default, "Spacing of quiver points in vector plot"),
         :offset => Pair(:default, "Offset of quiver grid"),
         :vscale => Pair(1.0, "Vector field scale for quiver grid"),
+        :vconstant => Pair(false, "Set all arrow length constant in vector plot"),
         :vnormalize => Pair(true, "Normalize vector field befor scaling"),
         :interior => Pair(true, "3D plot interior of grid"),
         :xplanes => Pair([prevfloat(Inf)], "3D x plane positions or number thereof"),


### PR DESCRIPTION
fixes current crashing of vectorplots if this kwarg is not set