### PR TITLE
Replace plottertypes by Singleton

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -14,15 +14,22 @@ save
 default_plotter
 default_plotter!
 plottertype
+PlotterType
 PythonPlotType
 PyPlotType
-MakieType
+UnionPythonPlotterType
+UnionMakieType
 PlotsType
 PlutoVistaType
 VTKViewType
 MeshCatType
+UnicodePlotsType
 ```
 
+### Deprecated Plottertypes
+```@docs
+MakieType
+```
 
 
 ## Plotting grids

--- a/docs/src/privapi.md
+++ b/docs/src/privapi.md
@@ -16,6 +16,8 @@ isplutovista
 isplots
 ismakie
 isvtkview
+ismeshcat
+isunicodeplots
 ```
 
 ## Makie

--- a/examples/plotting.jl
+++ b/examples/plotting.jl
@@ -199,7 +199,7 @@ end
 # ### Animation of function on 1D grid
 function anim_func1d(; Plotter = default_plotter(), kwargs...)
     step = 0.01
-    if ismakie(Plotter)
+    if plottertype(Plotter) <: UnionMakieType
         step = 0.0001
     end
     g = grid1d(; n = 50)
@@ -214,7 +214,7 @@ end
 # ### Animation of function on 2D grid
 function anim_func2d(; Plotter = default_plotter(), kwargs...)
     step = 0.05
-    if ismakie(Plotter)
+    if plottertype(Plotter) <: UnionMakieType
         step = 0.005
     end
     g = grid2d(; n = 30)
@@ -229,7 +229,7 @@ end
 # ### Animation of function on 3D grid
 function anim_func3d(; Plotter = default_plotter(), kwargs...)
     step = 0.05
-    if ismakie(Plotter)
+    if plottertype(Plotter) <: UnionMakieType
         step = 0.005
     end
     g = grid3d(; n = 15)
@@ -447,9 +447,9 @@ function plotting_custom(; Plotter = default_plotter(), kwargs...)
     grid = grid2d()
     gridplot!(vis, grid)
     customplot!(vis) do ax
-        ismakie(Plotter) && Plotter.scatter!(ax, rand(10), rand(10), fill(0.1, 10); color = :blue, markersize = 20)
-        ispyplot(Plotter) && ax.scatter(rand(10), rand(10); s = 500)
-        isplots(Plotter) && Plotter.scatter!(ax, rand(10), rand(10); color = :blue, markersize = 10, label = nothing)
+        plottertype(Plotter) <: UnionMakieType && Plotter.scatter!(ax, rand(10), rand(10), fill(0.1, 10); color = :blue, markersize = 20)
+        plottertype(Plotter) <: PyPlotType && ax.scatter(rand(10), rand(10); s = 500)
+        plottertype(Plotter) <: PlotsType && Plotter.scatter!(ax, rand(10), rand(10); color = :blue, markersize = 10, label = nothing)
     end
     return reveal(vis)
 end

--- a/ext/GridVisualizeMakieExt.jl
+++ b/ext/GridVisualizeMakieExt.jl
@@ -15,7 +15,7 @@ using Interpolations: linear_interpolation
 using IntervalSets
 
 import GridVisualize: initialize!, save, reveal, gridplot!, scalarplot!, vectorplot!, streamplot!, customplot!, movie, plot_triangulateio!
-using GridVisualize: MakieType, GridVisualizer, SubVisualizer
+using GridVisualize: UnionMakieType, GridVisualizer, SubVisualizer
 using GridVisualize: isolevels, cellcolors, num_cellcolors, vectorsample, quiverdata, regionmesh, bfacesegments
 
 using ExtendableGrids
@@ -24,7 +24,7 @@ using Observables
 
 include("flippablelayout.jl")
 
-function initialize!(p::GridVisualizer, ::Type{MakieType})
+function initialize!(p::GridVisualizer, ::Type{MakieType}) where {MakieType <: UnionMakieType}
     XMakie = p.context[:Plotter]
 
     # Prepare flippable layout
@@ -57,7 +57,7 @@ end
 add_scene!(ctx, ax) = ctx[:flayout][ctx[:subplot]...] = ax
 
 # Revealing the  visualizer just returns the figure
-function reveal(p::GridVisualizer, ::Type{MakieType})
+function reveal(p::GridVisualizer, ::Type{MakieType}) where {MakieType <: UnionMakieType}
     XMakie = p.context[:Plotter]
     layout = p.context[:layout]
     # For 1D plots the legend should be rendered only once,
@@ -84,7 +84,7 @@ function reveal(p::GridVisualizer, ::Type{MakieType})
     end
 end
 
-function reveal(ctx::SubVisualizer, TP::Type{MakieType})
+function reveal(ctx::SubVisualizer, TP::Type{MakieType}) where {MakieType <: UnionMakieType}
     FlippableLayout.yieldwait(ctx[:flayout])
     if ctx[:show] || ctx[:reveal]
         return reveal(ctx[:GridVisualizer], TP)
@@ -92,10 +92,10 @@ function reveal(ctx::SubVisualizer, TP::Type{MakieType})
     return nothing
 end
 
-function save(fname, p::GridVisualizer, ::Type{MakieType})
+function save(fname, p::GridVisualizer, ::Type{MakieType}) where {MakieType <: UnionMakieType}
     return p.context[:Plotter].save(fname, p.context[:figure])
 end
-function save(fname, scene, XMakie, ::Type{MakieType})
+function save(fname, scene, XMakie, ::Type{MakieType}) where {MakieType <: UnionMakieType}
     return isnothing(scene) ? nothing : XMakie.save(fname, scene)
 end
 
@@ -107,7 +107,7 @@ function movie(
         file = nothing,
         format = "gif",
         kwargs...,
-    )
+    ) where {MakieType <: UnionMakieType}
     Plotter = vis.context[:Plotter]
     if !isnothing(file)
         format = lstrip(splitext(file)[2], '.')
@@ -276,7 +276,7 @@ function scenecorners1d(grid, gridscale)
 end
 
 # 1D version
-function gridplot!(ctx, TP::Type{MakieType}, ::Type{Val{1}}, grid)
+function gridplot!(ctx, TP::Type{MakieType}, ::Type{Val{1}}, grid) where {MakieType <: UnionMakieType}
     XMakie = ctx[:Plotter]
     nregions = num_cellregions(grid)
     nbregions = num_bfaceregions(grid)
@@ -354,7 +354,7 @@ end
 ########################################################################
 # 1D function
 
-function scalarplot!(ctx, TP::Type{MakieType}, ::Type{Val{1}}, grids, parentgrid, funcs)
+function scalarplot!(ctx, TP::Type{MakieType}, ::Type{Val{1}}, grids, parentgrid, funcs) where {MakieType <: UnionMakieType}
     XMakie = ctx[:Plotter]
 
     nfuncs = length(funcs)
@@ -616,7 +616,7 @@ function set_plot_data!(ctx, key, data)
     return haskey(ctx, key) ? ctx[key][] = data : ctx[key] = Observable(data)
 end
 
-function gridplot!(ctx, TP::Type{MakieType}, ::Type{Val{2}}, grid)
+function gridplot!(ctx, TP::Type{MakieType}, ::Type{Val{2}}, grid) where {MakieType <: UnionMakieType}
     XMakie = ctx[:Plotter]
 
     nregions = num_cellcolors(grid, ctx[:cellcoloring])
@@ -731,7 +731,7 @@ function makescene2d(ctx, key)
 end
 
 # 2D function
-function scalarplot!(ctx, TP::Type{MakieType}, ::Type{Val{2}}, grids, parentgrid, funcs)
+function scalarplot!(ctx, TP::Type{MakieType}, ::Type{Val{2}}, grids, parentgrid, funcs) where {MakieType <: UnionMakieType}
     XMakie = ctx[:Plotter]
     gridscale = ctx[:gridscale]
 
@@ -869,7 +869,7 @@ function scalarplot!(ctx, TP::Type{MakieType}, ::Type{Val{2}}, grids, parentgrid
 end
 
 # 2D vector
-function vectorplot!(ctx, TP::Type{MakieType}, ::Type{Val{2}}, grid, func)
+function vectorplot!(ctx, TP::Type{MakieType}, ::Type{Val{2}}, grid, func) where {MakieType <: UnionMakieType}
     XMakie = ctx[:Plotter]
 
     rc, rv = vectorsample(grid, func; gridscale = ctx[:gridscale], rasterpoints = ctx[:rasterpoints], offset = ctx[:offset])
@@ -914,7 +914,7 @@ function vectorplot!(ctx, TP::Type{MakieType}, ::Type{Val{2}}, grid, func)
     return reveal(ctx, TP)
 end
 
-function streamplot!(ctx, TP::Type{MakieType}, ::Type{Val{2}}, grid, func)
+function streamplot!(ctx, TP::Type{MakieType}, ::Type{Val{2}}, grid, func) where {MakieType <: UnionMakieType}
     XMakie = ctx[:Plotter]
 
     rc, rv = vectorsample(
@@ -1080,7 +1080,7 @@ pgup/pgdown: coarse control control value
           h: print this message
 """
 
-function gridplot!(ctx, TP::Type{MakieType}, ::Type{Val{3}}, grid)
+function gridplot!(ctx, TP::Type{MakieType}, ::Type{Val{3}}, grid) where {MakieType <: UnionMakieType}
     function make_mesh(pts, fcs)
         if pkgversion(GeometryBasics) < v"0.5"
             return GeometryBasics.Mesh(meta(pts; normals = normals(pts, fcs)), fcs)
@@ -1273,7 +1273,7 @@ function gridplot!(ctx, TP::Type{MakieType}, ::Type{Val{3}}, grid)
 end
 
 # 3d function
-function scalarplot!(ctx, TP::Type{MakieType}, ::Type{Val{3}}, grids, parentgrid, funcs)
+function scalarplot!(ctx, TP::Type{MakieType}, ::Type{Val{3}}, grids, parentgrid, funcs) where {MakieType <: UnionMakieType}
     levels, crange, colorbarticks = isolevels(ctx, funcs)
     ctx[:crange] = crange
     ctx[:colorbarticks] = colorbarticks
@@ -1514,7 +1514,7 @@ end
 # Thanks!  lines(x, y, axis = (targetlimits = lims,))  indeed makes the limits update.^
 # I found that autolimits!(axis) gave good results, even better than me manually computing limits!
 
-function customplot!(ctx, TP::Type{MakieType}, func)
+function customplot!(ctx, TP::Type{MakieType}, func) where {MakieType <: UnionMakieType}
     XMakie = ctx[:Plotter]
     if !haskey(ctx, :scene)
         ctx[:scene] = XMakie.Axis(
@@ -1539,7 +1539,7 @@ function plot_triangulateio!(
         voronoi = nothing,
         circumcircles = false,
         kwargs...
-    )
+    ) where {MakieType <: UnionMakieType}
     XMakie = ctx[:Plotter]
 
     function frgb(Plotter, i, max; pastel = false)

--- a/src/GridVisualize.jl
+++ b/src/GridVisualize.jl
@@ -22,6 +22,7 @@ include("dispatch.jl")
 include("common.jl")
 include("pycommon.jl")
 include("slice_plots.jl")
+include("deprecated.jl")
 
 export scalarplot, scalarplot!
 export gridplot, gridplot!
@@ -31,11 +32,11 @@ export customplot, customplot!
 export quiverdata, vectorsample
 export plot_triangulateio, plot_triangulateio!
 export save, reveal
-export isplots, isvtkview, ispyplot, ispythonplot, ismakie, isplutovista
 export GridVisualizer, SubVisualizer
 export plottertype, available_kwargs
 export default_plotter!, default_plotter
-export PyPlotType, PythonPlotType, MakieType, PlotsType, VTKViewType, PlutoVistaType, MeshCatType
+export PlotterType, PyPlotType, PythonPlotType, UnionPythonPlotterType, UnionMakieType, PlotsType, VTKViewType, PlutoVistaType, MeshCatType, UnicodePlotsType
+export isvtkview, ispyplot, ispythonplot, isplots, ismakie, ismeshcat, isplutovista, isunicodeplots
 export movie
 
 end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,0 +1,9 @@
+"""
+    const MakieType = UnionMakieType
+
+Deprecated parent type for dispatch on Makie plotters.
+"""
+const MakieType = UnionMakieType
+Base.@deprecate_binding MakieType UnionMakieType
+
+export MakieType

--- a/src/dispatch.jl
+++ b/src/dispatch.jl
@@ -22,161 +22,168 @@ function default_plotter!(Plotter)
 end
 
 """
-$(SIGNATURES)
-
-Heuristically check if Plotter is VTKView
-"""
-isvtkview(Plotter) = (typeof(Plotter) == Module) && isdefined(Plotter, :StaticFrame)
-
-"""
-$(SIGNATURES)
-
-Heuristically check if Plotter is PyPlot
-"""
-ispyplot(Plotter) = (typeof(Plotter) == Module) && isdefined(Plotter, :Gcf)  && !isdefined(Plotter, :plotshow)
-
-"""
-$(SIGNATURES)
-
-Heuristically check if Plotter is PythonPlot
-"""
-ispythonplot(Plotter) = (typeof(Plotter) == Module) && isdefined(Plotter, :Gcf) && isdefined(Plotter, :plotshow)
-
-"""
-$(SIGNATURES)
-
-Heuristically check if  Plotter is Plots
-"""
-isplots(Plotter) = (typeof(Plotter) == Module) && isdefined(Plotter, :gr)
-
-"""
-$(SIGNATURES)
-
-Heuristically check if Plotter is Makie/WGLMakie
-"""
-ismakie(Plotter) = (typeof(Plotter) == Module) && isdefined(Plotter, :Makie)
-
-"""
-$(SIGNATURES)
-
-Heuristically check if Plotter is MeshCat
-"""
-ismeshcat(Plotter) = (typeof(Plotter) == Module) && isdefined(Plotter, :Visualizer)
-
-"""
-$(SIGNATURES)
-
-Heuristically check if Plotter is PlutoVista
-"""
-isplutovista(Plotter) = (typeof(Plotter) == Module) && isdefined(Plotter, :PlutoVistaPlot)
-
-"""
-$(SIGNATURES)
-
-Heuristically check if Plotter is UnicodePlots
-"""
-isunicodeplots(Plotter) = (typeof(Plotter) == Module) && isdefined(Plotter, :BrailleCanvas)
-
-"""
 $(TYPEDEF)
 
 Abstract type for dispatching on plotter
 """
 abstract type AbstractPlotterType end
 
+"""
+$(TYPEDEF)
 
-abstract type AbstractPythonPlotterType <: AbstractPlotterType end
+Singleton type for dispatching on plotter
+"""
+struct PlotterType{T} <: AbstractPlotterType end
+
+"""
+    const PyPlotType = PlotterType{:PyPlot}
+
+Shorthand for PyPlot PlotterType Singleton.
+"""
+const PyPlotType = PlotterType{:PyPlot}
+
+"""
+    const PythonPlotType = PlotterType{:PythonPlot}
+
+Shorthand for PythonPlot PlotterType Singleton.
+"""
+const PythonPlotType = PlotterType{:PythonPlot}
+
+"""
+    const PlotsType = PlotterType{:Plots}
+
+Shorthand for Plots PlotterType Singleton.
+"""
+const PlotsType = PlotterType{:Plots}
+
+"""
+    const PlutoVistaType = PlotterType{:PlutoVista}
+
+Shorthand for PlutoVista PlotterType Singleton.
+"""
+const PlutoVistaType = PlotterType{:PlutoVista}
+
+"""
+    const VTKViewType = PlotterType{:VTKView}
+
+Shorthand for VTKView PlotterType Singleton. Experimental
+"""
+const VTKViewType = PlotterType{:VTKView}
+
+"""
+    const MeshCatType = PlotterType{:MeshCat}
+
+Shorthand for MeshCat PlotterType Singleton. Experimental
+"""
+const MeshCatType = PlotterType{:MeshCat}
+
+"""
+    const UnionPythonPlotterType = Union{PyPlotType,PythonPlotType}
+
+Parent type for dispatch on Python plotters.
+"""
+const UnionPythonPlotterType = Union{PyPlotType, PythonPlotType}
+
+"""
+    const UnionMakieType = Union{PlotterType{:CairoMakie},PlotterType{:WGLMakie},PlotterType{:RPRMakie}}
+
+Parent type for dispatch on Makie plotters.
+"""
+const UnionMakieType = Union{PlotterType{:CairoMakie}, PlotterType{:WGLMakie}, PlotterType{:RPRMakie}}
 
 """
 $(TYPEDEF)
 
-Abstract type for dispatching on plotter
+Shorthand for dispatch on UnicodePlots
 """
-abstract type PyPlotType <: AbstractPythonPlotterType end
-
-"""
-$(TYPEDEF)
-
-Abstract type for dispatching on plotter
-"""
-abstract type PythonPlotType <: AbstractPythonPlotterType end
-
-"""
-$(TYPEDEF)
-
-Abstract type for dispatching on plotter
-"""
-abstract type MakieType <: AbstractPlotterType end
-
-"""
-$(TYPEDEF)
-
-Abstract type for dispatching on plotter
-"""
-abstract type PlotsType <: AbstractPlotterType end
-
-"""
-$(TYPEDEF)
-
-Abstract type for dispatching on plotter. Experimental.
-"""
-abstract type VTKViewType <: AbstractPlotterType end
-
-"""
-$(TYPEDEF)
-
-Abstract type for dispatching on plotter. Experimental.
-"""
-abstract type MeshCatType <: AbstractPlotterType end
-
-"""
-$(TYPEDEF)
-
-Abstract type for dispatching on plotter
-"""
-abstract type PlutoVistaType <: AbstractPlotterType end
-
-"""
-$(TYPEDEF)
-
-Abstract type for dispatching on plotter
-"""
-abstract type UnicodePlotsType <: AbstractPlotterType end
+const UnicodePlotsType = PlotterType{:UnicodePlots}
 
 """
 $(SIGNATURES)
-    
-Heuristically detect type of plotter, returns the corresponding abstract type for plotting.
+
+Obtain Singleton type of given Plotter.
 """
-function plottertype(Plotter::Union{Module, Nothing})
-    if ismakie(Plotter)
-        return MakieType
-    elseif isplots(Plotter)
-        return PlotsType
-    elseif ispyplot(Plotter)
-        return PyPlotType
-    elseif ispythonplot(Plotter)
-        return PythonPlotType
-    elseif isvtkview(Plotter)
-        return VTKViewType
-    elseif ismeshcat(Plotter)
-        return MeshCatType
-    elseif isplutovista(Plotter)
-        return PlutoVistaType
-    elseif isunicodeplots(Plotter)
-        return UnicodePlotsType
-    end
-    return Nothing
+plottertype(Plotter::Module) = PlotterType{nameof(Plotter)}
+plottertype(::Nothing) = Type{Nothing}
+
+"""
+$(SIGNATURES)
+
+Heuristically check if Plotter is VTKView
+"""
+function isvtkview(Plotter)
+    return plottertype(Plotter) <: VTKViewType
 end
 
-plottername(::Type{MakieType}) = "Makie"
-plottername(::Type{PlotsType}) = "Plots"
-plottername(::Type{PyPlotType}) = "PyPlot"
-plottername(::Type{PythonPlotType}) = "PythonPlot"
-plottername(::Type{PlutoVistaType}) = "PlutoVista"
-plottername(::Type{UnicodePlotsType}) = "UnicodePlots"
-plottername(::Type{VTKViewType}) = "VTKView"
-plottername(::Type{MeshCatType}) = "MeshCat"
+"""
+$(SIGNATURES)
+
+Heuristically check if Plotter is PyPlot
+"""
+function ispyplot(Plotter)
+    return plottertype(Plotter) <: PyPlotType
+end
+
+"""
+$(SIGNATURES)
+
+Heuristically check if Plotter is PythonPlot
+"""
+function ispythonplot(Plotter)
+    return plottertype(Plotter) <: PythonPlotType
+end
+
+"""
+$(SIGNATURES)
+
+Heuristically check if  Plotter is Plots
+"""
+function isplots(Plotter)
+    return plottertype(Plotter) <: PlotsType
+end
+
+"""
+$(SIGNATURES)
+
+Heuristically check if Plotter is Makie/WGLMakie
+"""
+function ismakie(Plotter)
+    return plottertype(Plotter) <: UnionMakieType
+end
+
+"""
+$(SIGNATURES)
+
+Heuristically check if Plotter is MeshCat
+"""
+function ismeshcat(Plotter)
+    return plottertype(Plotter) <: MeshCatType
+end
+
+"""
+$(SIGNATURES)
+
+Heuristically check if Plotter is PlutoVista
+"""
+function isplutovista(Plotter)
+    return plottertype(Plotter) <: PlutoVistaType
+end
+
+"""
+$(SIGNATURES)
+
+Heuristically check if Plotter is UnicodePlots
+"""
+function isunicodeplots(Plotter)
+    return plottertype(Plotter) <: UnicodePlotsType
+end
+
+"""
+$(SIGNATURES)
+
+Obtain name of PlotterType
+"""
+plottername(::PlotterType{T}) where {T} = String(T)
 plottername(::Type{Nothing}) = "nothing"
 plottername(p::Union{Module, Nothing}) = plottertype(p) |> plottername
 
@@ -293,7 +300,7 @@ function initialize!(p, ::Type{T}) where {T <: AbstractPlotterType}
 end
 
 function Base.show(io::IO, mime::MIME"text/html", p::GridVisualizer)
-    if isplutovista(p.Plotter)
+    if plottertype(p.Plotter) <: PlutoVistaType
         show(io, mime, p.subplots[1][:figure])
     else
         output = """<code>GridVisualizer(Plotter=$(p.Plotter))</code>"""

--- a/src/pycommon.jl
+++ b/src/pycommon.jl
@@ -1,4 +1,4 @@
-function initialize!(p, ::Type{T}) where {T <: AbstractPythonPlotterType}
+function initialize!(p, ::Type{T}) where {T <: UnionPythonPlotterType}
     PyPlotter = p.context[:Plotter]
     PyPlotter.rc("font"; size = p.context[:fontsize])
     if !haskey(p.context, :figure)
@@ -24,15 +24,15 @@ function initialize!(p, ::Type{T}) where {T <: AbstractPythonPlotterType}
     return nothing
 end
 
-function save(fname, p, ::Type{T}) where {T <: AbstractPythonPlotterType}
+function save(fname, p, ::Type{T}) where {T <: UnionPythonPlotterType}
     return p.context[:figure].savefig(fname)
 end
 
-function save(fname, scene, PyPlotter, ::Type{T}) where {T <: AbstractPythonPlotterType}
+function save(fname, scene, PyPlotter, ::Type{T}) where {T <: UnionPythonPlotterType}
     return isnothing(scene) ? nothing : scene.savefig(fname)
 end
 
-function reveal(p::GridVisualizer, ::Type{T}) where {T <: AbstractPythonPlotterType}
+function reveal(p::GridVisualizer, ::Type{T}) where {T <: UnionPythonPlotterType}
     p.context[:revealed] = true
     p.Plotter.tight_layout()
     if !(isdefined(Main, :PlutoRunner)) && isinteractive()
@@ -46,7 +46,7 @@ function reveal(p::GridVisualizer, ::Type{T}) where {T <: AbstractPythonPlotterT
     return current_figure
 end
 
-function reveal(ctx::SubVisualizer, TP::Type{T}) where {T <: AbstractPythonPlotterType}
+function reveal(ctx::SubVisualizer, TP::Type{T}) where {T <: UnionPythonPlotterType}
     yield()
     if ctx[:show] || ctx[:reveal]
         reveal(ctx[:GridVisualizer], TP)
@@ -123,7 +123,7 @@ end
 plaincolormap(ctx) = colorschemes[ctx[:colormap]].colors
 
 ### 1D grid
-function gridplot!(ctx, TP::Type{T}, ::Type{Val{1}}, grid) where {T <: AbstractPythonPlotterType}
+function gridplot!(ctx, TP::Type{T}, ::Type{Val{1}}, grid) where {T <: UnionPythonPlotterType}
     PyPlotter = ctx[:Plotter]
 
     if !haskey(ctx, :ax)
@@ -200,7 +200,7 @@ function gridplot!(ctx, TP::Type{T}, ::Type{Val{1}}, grid) where {T <: AbstractP
 end
 
 ### 2D grid
-function gridplot!(ctx, TP::Type{T}, ::Type{Val{2}}, grid) where {T <: AbstractPythonPlotterType}
+function gridplot!(ctx, TP::Type{T}, ::Type{Val{2}}, grid) where {T <: UnionPythonPlotterType}
     PyPlotter = ctx[:Plotter]
     if !haskey(ctx, :ax)
         ctx[:ax] = ctx[:figure].add_subplot(ctx[:layout]..., ctx[:iplot])
@@ -316,7 +316,7 @@ function gridplot!(ctx, TP::Type{T}, ::Type{Val{2}}, grid) where {T <: AbstractP
 end
 
 ### 3D Grid
-function gridplot!(ctx, TP::Type{T}, ::Type{Val{3}}, grid) where {T <: AbstractPythonPlotterType}
+function gridplot!(ctx, TP::Type{T}, ::Type{Val{3}}, grid) where {T <: UnionPythonPlotterType}
     # See https://jakevdp.github.io/PythonDataScienceHandbook/04.12-three-dimensional-plotting.html
 
     PyPlotter = ctx[:Plotter]
@@ -416,7 +416,7 @@ function gridplot!(ctx, TP::Type{T}, ::Type{Val{3}}, grid) where {T <: AbstractP
 end
 
 ### 1D Function
-function scalarplot!(ctx, TP::Type{T}, ::Type{Val{1}}, grids, parentgrid, funcs) where {T <: AbstractPythonPlotterType}
+function scalarplot!(ctx, TP::Type{T}, ::Type{Val{1}}, grids, parentgrid, funcs) where {T <: UnionPythonPlotterType}
     PyPlotter = ctx[:Plotter]
     nfuncs = length(funcs)
 
@@ -544,7 +544,7 @@ function scalarplot!(ctx, TP::Type{T}, ::Type{Val{1}}, grids, parentgrid, funcs)
 end
 
 ### 2D Function
-function scalarplot!(ctx, TP::Type{T}, ::Type{Val{2}}, grids, parentgrid, funcs) where {T <: AbstractPythonPlotterType}
+function scalarplot!(ctx, TP::Type{T}, ::Type{Val{2}}, grids, parentgrid, funcs) where {T <: UnionPythonPlotterType}
     PyPlotter = ctx[:Plotter]
     if !haskey(ctx, :ax)
         ctx[:ax] = ctx[:figure].add_subplot(ctx[:layout]..., ctx[:iplot])
@@ -629,7 +629,7 @@ function scalarplot!(ctx, TP::Type{T}, ::Type{Val{2}}, grids, parentgrid, funcs)
     return reveal(ctx, TP)
 end
 
-function scalarplot!(ctx, TP::Type{T}, ::Type{Val{3}}, grids, parentgrid, funcs) where {T <: AbstractPythonPlotterType}
+function scalarplot!(ctx, TP::Type{T}, ::Type{Val{3}}, grids, parentgrid, funcs) where {T <: UnionPythonPlotterType}
     PyPlotter = ctx[:Plotter]
     if !haskey(ctx, :ax)
         ctx[:ax] = ctx[:figure].add_subplot(ctx[:layout]..., ctx[:iplot]; projection = "3d")
@@ -717,7 +717,7 @@ function scalarplot!(ctx, TP::Type{T}, ::Type{Val{3}}, grids, parentgrid, funcs)
 end
 
 ### 2D Vector
-function vectorplot!(ctx, TP::Type{T}, ::Type{Val{2}}, grid, func) where {T <: AbstractPythonPlotterType}
+function vectorplot!(ctx, TP::Type{T}, ::Type{Val{2}}, grid, func) where {T <: UnionPythonPlotterType}
     PyPlotter = ctx[:Plotter]
     if !haskey(ctx, :ax)
         ctx[:ax] = ctx[:figure].add_subplot(ctx[:layout]..., ctx[:iplot])
@@ -761,7 +761,7 @@ function vectorplot!(ctx, TP::Type{T}, ::Type{Val{2}}, grid, func) where {T <: A
 end
 
 ### 2D stream
-function streamplot!(ctx, TP::Type{T}, ::Type{Val{2}}, grid, func) where {T <: AbstractPythonPlotterType}
+function streamplot!(ctx, TP::Type{T}, ::Type{Val{2}}, grid, func) where {T <: UnionPythonPlotterType}
     PyPlotter = ctx[:Plotter]
     if !haskey(ctx, :ax)
         ctx[:ax] = ctx[:figure].add_subplot(ctx[:layout]..., ctx[:iplot])
@@ -800,7 +800,7 @@ function streamplot!(ctx, TP::Type{T}, ::Type{Val{2}}, grid, func) where {T <: A
     return reveal(ctx, TP)
 end
 
-function customplot!(ctx, TP::Type{T}, func) where {T <: AbstractPythonPlotterType}
+function customplot!(ctx, TP::Type{T}, func) where {T <: UnionPythonPlotterType}
     PyPlotter = ctx[:Plotter]
     if !haskey(ctx, :ax)
         ctx[:ax] = ctx[:figure].add_subplot(ctx[:layout]..., ctx[:iplot])
@@ -823,7 +823,7 @@ function plot_triangulateio!(
         voronoi = nothing,
         circumcircles = false,
         kwargs...
-    ) where {T <: AbstractPythonPlotterType}
+    ) where {T <: UnionPythonPlotterType}
 
     function frgb(Plotter, i, max; pastel = false)
         x = Float64(i - 1) / Float64(max)


### PR DESCRIPTION
As proposed in #108 this changes dispatch.jl to use Singletons instead of using the set of nested ifs in `plottertype` with ismakie() and similar. 

Since `MakieType` was heuristic based I had to introduce the alternative `AbstractMakieType` and change the Makie extension accordingly by adding `where {MakieType <: AbstractMakieType}` where needed. 
Then all tests ran locally without problem.

Now, extending GridVisualize with another plotting backend can be done without needing to touch the main package.
Nevertheless, introducing a new shorthand through `const AnotherPlotterPackageType = PlotterType{:AnotherPlotterPackage}`
is certainly nice and quickly done. 

@j-fu do you know of any downstream package that might explicitly use `MakieType`?

And if you are fine with this we should test the alternative to the example to remove the !private! functions ismakie and similar.