### PR TITLE
Enable customizable colors for cell and boundary regions to `gridplot`

### DIFF
--- a/examples/plotting.jl
+++ b/examples/plotting.jl
@@ -38,9 +38,23 @@ function grid2d(; n = 20)
     return g = simplexgrid(X, X)
 end
 
-function plotting_grid2d(; Plotter = default_plotter(), kwargs...)
-    return gridplot(grid2d(); Plotter = Plotter, kwargs...)
+# We can also set custom colors for the cellregions and
+# boundary regions by providing a function that returns
+# a list of `nregions` colors via the `cellregioncolormap`
+# or `bregioncolormap` keywords.
+
+function custom_cellcolors(ncellregions)
+    return [:firebrick]
 end
+
+function custom_bregioncolors(nbregions)
+    return [:teal, :darkgreen, :darkmagenta, :navy]
+end
+
+function plotting_grid2d(; Plotter = default_plotter(), kwargs...)
+    return gridplot(grid2d(); Plotter = Plotter, cellregioncolormap = custom_cellcolors, bregioncolormap = custom_bregioncolors, kwargs...)
+end
+
 # ![](plotting_grid2d.png)
 
 # ### 3D grids

--- a/ext/GridVisualizeMakieExt.jl
+++ b/ext/GridVisualizeMakieExt.jl
@@ -653,7 +653,7 @@ function gridplot!(ctx, TP::Type{MakieType}, ::Type{Val{2}}, grid)
             end
         end
         # Draw cells with region mark
-        cmap = region_cmap(nregions)
+        cmap = ctx[:cellregioncolormap](nregions)
         ctx[:cmap] = cmap
         for i in 1:nregions
             XMakie.poly!(
@@ -666,7 +666,7 @@ function gridplot!(ctx, TP::Type{MakieType}, ::Type{Val{2}}, grid)
         end
 
         # Draw boundary lines
-        bcmap = bregion_cmap(nbregions)
+        bcmap = ctx[:bregioncolormap](nbregions)
         ctx[:bcmap] = bcmap
         for i in 1:nbregions
             lp = XMakie.linesegments!(
@@ -1124,9 +1124,9 @@ function gridplot!(ctx, TP::Type{MakieType}, ::Type{Val{3}}, grid)
         )
 
         ctx[:scene] = makeaxis3d(ctx)
-        cmap = region_cmap(nregions)
+        cmap = ctx[:cellregioncolormap](nregions)
         ctx[:cmap] = cmap
-        bcmap = bregion_cmap(nbregions)
+        bcmap = ctx[:bregioncolormap](nbregions)
         ctx[:bcmap] = bcmap
 
         ############# Interior cuts
@@ -1375,7 +1375,7 @@ function scalarplot!(ctx, TP::Type{MakieType}, ::Type{Val{3}}, grids, parentgrid
                 d -> [make_mesh(d[1][i], d[2][i]) for i in 1:nbregions],
                 ctx[:outlinedata]
             )
-            bcmap = bregion_cmap(nbregions)
+            bcmap = ctx[:bregioncolormap](nbregions)
             for i in 1:nbregions
                 XMakie.mesh!(
                     ctx[:scene],

--- a/ext/GridVisualizeMeshCatExt.jl
+++ b/ext/GridVisualizeMeshCatExt.jl
@@ -56,8 +56,8 @@ function gridplot!(ctx, TP::Type{MeshCatType}, ::Type{Val{2}}, grid)
     nregions = num_cellregions(grid)
     nbregions = num_bfaceregions(grid)
 
-    cmap = region_cmap(nregions)
-    bcmap = bregion_cmap(nbregions)
+    cmap = ctx[:cellregioncolormap](nregions)
+    bcmap = ctx[:bregioncolormap](nbregions)
     for i in 1:nregions
         mesh = regionmesh(grid, 1.0, i; cellcoloring = ctx[:cellcoloring])
         MeshCat.setobject!(
@@ -92,8 +92,8 @@ function gridplot!(ctx, TP::Type{MeshCatType}, ::Type{Val{3}}, grid)
 
     nregions = num_cellregions(grid)
     nbregions = num_bfaceregions(grid)
-    cmap = region_cmap(nregions)
-    bcmap = bregion_cmap(nbregions)
+    cmap = ctx[:cellregioncolormap](nregions)
+    bcmap = ctx[:bregioncolormap](nbregions)
 
     xyzmin = zeros(3)
     xyzmax = ones(3)
@@ -173,7 +173,7 @@ function scalarplot!(ctx, TP::Type{MeshCatType}, ::Type{Val{3}}, grids, parentgr
 
     nregions = num_cellregions(grid)
     nbregions = num_bfaceregions(grid)
-    bcmap = bregion_cmap(nbregions)
+    bcmap = ctx[:bregioncolormap](nbregions)
     xyzmin = zeros(3)
     xyzmax = ones(3)
     coord = grid[Coordinates]

--- a/ext/GridVisualizePlotsExt.jl
+++ b/ext/GridVisualizePlotsExt.jl
@@ -116,7 +116,7 @@ function gridplot!(ctx, TP::Type{PlotsType}, ::Type{Val{1}}, grid)
     xmax = maximum(coord) * gridscale
     h = (xmax - xmin) / 20.0
 
-    cmap = region_cmap(ncellregions)
+    cmap = ctx[:cellregioncolormap](ncellregions)
     for icell in 1:num_cells(grid)
         x1 = coord[1, cellnodes[1, icell]] * gridscale
         x2 = coord[1, cellnodes[2, icell]] * gridscale
@@ -132,7 +132,7 @@ function gridplot!(ctx, TP::Type{PlotsType}, ::Type{Val{1}}, grid)
         )
     end
 
-    cmap = bregion_cmap(nbfaceregions)
+    cmap = ctx[:bregioncolormap](nbfaceregions)
     for ibface in 1:num_bfaces(grid)
         if bfaceregions[ibface] > 0
             x1 = coord[1, bfacenodes[1, ibface]] * gridscale
@@ -163,7 +163,7 @@ function gridplot!(ctx, TP::Type{PlotsType}, ::Type{Val{2}}, grid)
     bfaceregions = grid[BFaceRegions]
     nbfaceregions = grid[NumBFaceRegions]
 
-    cmap = region_cmap(ncellregions)
+    cmap = ctx[:cellregioncolormap](ncellregions)
     for icell in 1:num_cells(grid)
         inode1 = cellnodes[1, icell]
         inode2 = cellnodes[2, icell]
@@ -205,7 +205,7 @@ function gridplot!(ctx, TP::Type{PlotsType}, ::Type{Val{2}}, grid)
         )
     end
 
-    cmap = bregion_cmap(nbfaceregions)
+    cmap = ctx[:bregioncolormap](nbfaceregions)
     for ibface in 1:num_bfaces(grid)
         inode1 = bfacenodes[1, ibface]
         inode2 = bfacenodes[2, ibface]

--- a/ext/GridVisualizePlutoVistaExt.jl
+++ b/ext/GridVisualizePlutoVistaExt.jl
@@ -148,7 +148,7 @@ function gridplot!(ctx, TP::Type{PlutoVistaType}, ::Type{Val{1}}, grid)
     #    ax.set_aspect(ctx[:aspect])
     #    ax.get_yaxis().set_ticks([])
     #    ax.set_ylim(-5*h,xmax-xmin)
-    cmap = region_cmap(ncellregions)
+    cmap = ctx[:cellregioncolormap](ncellregions)
 
     for icell in 1:num_cells(grid)
         ireg = cellregions[icell]
@@ -185,7 +185,7 @@ function gridplot!(ctx, TP::Type{PlutoVistaType}, ::Type{Val{1}}, grid)
         )
     end
 
-    cmap = bregion_cmap(nbfaceregions)
+    cmap = ctx[:bregioncolormap](nbfaceregions)
     for ibface in 1:num_bfaces(grid)
         ireg = bfaceregions[ibface]
         if ireg > 0
@@ -280,8 +280,8 @@ end
 function gridplot!(ctx, TP::Type{PlutoVistaType}, ::Type{Val{2}}, grid)
     nregions = num_cellcolors(grid, ctx[:cellcoloring])
     nbregions = num_bfaceregions(grid)
-    cmap = region_cmap(nregions)
-    bcmap = bregion_cmap(nbregions)
+    cmap = ctx[:cellregioncolormap](nregions)
+    bcmap = ctx[:bregioncolormap](nbregions)
     PlutoVista = ctx[:Plotter]
     pts = grid[Coordinates]
     tris = grid[CellNodes]
@@ -387,8 +387,8 @@ function streamplot!(ctx, TP::Type{PlutoVistaType}, ::Type{Val{2}}, grid, func) 
 function gridplot!(ctx, TP::Type{PlutoVistaType}, ::Type{Val{3}}, grid)
     nbregions = num_bfaceregions(grid)
     nregions = num_cellcolors(grid, ctx[:cellcoloring])
-    cmap = region_cmap(nregions)
-    bcmap = bregion_cmap(nbregions)
+    cmap = ctx[:cellregioncolormap](nregions)
+    bcmap = ctx[:bregioncolormap](nbregions)
 
     PlutoVista = ctx[:Plotter]
     pts = grid[Coordinates]
@@ -440,7 +440,7 @@ function scalarplot!(
     )
     PlutoVista = ctx[:Plotter]
     nbregions = num_bfaceregions(parentgrid)
-    bcmap = bregion_cmap(nbregions)
+    bcmap = ctx[:bregioncolormap](nbregions)
 
     faces = parentgrid[BFaceNodes]
     facemarkers = parentgrid[BFaceRegions]

--- a/src/dispatch.jl
+++ b/src/dispatch.jl
@@ -318,6 +318,14 @@ function default_plot_kwargs()
             :cellregions,
             "Coloring of cells: one of [:cellregions, :pcolors, :partitions]"
         ),
+        :cellregioncolormap => Pair(
+            region_cmap,
+            "Function returning the colormap for cell regions in `gridplot`: takes `nregions` and returns a suitable colormap"
+        ),
+        :bregioncolormap => Pair(
+            bregion_cmap,
+            "Function returning the colormap for boundary regions in `gridplot`: takes `nbregions` and returns a suitable colormap"
+        ),
         :cellwise => Pair(false, "1D plots cellwise; unmaintained and can be slow)"),
         :clear => Pair(true, "Clear plot before adding new content"),
         :color => Pair(RGB(0.0, 0.0, 0.0), "1D plot line color"),

--- a/src/pycommon.jl
+++ b/src/pycommon.jl
@@ -152,7 +152,7 @@ function gridplot!(ctx, TP::Type{T}, ::Type{Val{1}}, grid) where {T <: AbstractP
     ax.set_title(ctx[:title])
     ax.set_xlabel(ctx[:xlabel])
 
-    cmap = region_cmap(max(ncellregions, 5))
+    cmap = ctx[:cellregioncolormap](max(ncellregions, 5))
     gridscale = ctx[:gridscale]
 
     for icell in 1:num_cells(grid)
@@ -173,7 +173,7 @@ function gridplot!(ctx, TP::Type{T}, ::Type{Val{1}}, grid) where {T <: AbstractP
         ax.plot([x2, x2], [-h, h]; linewidth = ctx[:linewidth], color = "k", label = "")
     end
 
-    cmap = bregion_cmap(max(nbfaceregions, 5))
+    cmap = ctx[:bregioncolormap](max(nbfaceregions, 5))
     for ibface in 1:num_bfaces(grid)
         ireg = bfaceregions[ibface]
         if ireg > 0
@@ -233,8 +233,8 @@ function gridplot!(ctx, TP::Type{T}, ::Type{Val{2}}, grid) where {T <: AbstractP
     ax.set_aspect(ctx[:aspect])
     tridat = tridata(grid, ctx[:gridscale])
     # PyPlotter.ColorMap cannot handle n ≤ 1, TODO: use single color instead of a color map
-    cmap = region_cmap(max(2, ncellregions))
-    bcmap = bregion_cmap(max(2, nbfaceregions))
+    cmap = ctx[:cellregioncolormap](max(2, ncellregions))
+    bcmap = ctx[:bregioncolormap](max(2, nbfaceregions))
 
     cell_colors = cellcolors(grid, ctx[:cellcoloring])
 
@@ -287,7 +287,7 @@ function gridplot!(ctx, TP::Type{T}, ::Type{Val{2}}, grid) where {T <: AbstractP
     if nbfaceregions > 0
         gridscale = ctx[:gridscale]
         coord = grid[Coordinates]
-        cmap = bregion_cmap(max(nbfaceregions, 5))
+        cmap = ctx[:bregioncolormap](max(nbfaceregions, 5))
         # see https://gist.github.com/gizmaa/7214002
         c1 = [coord[:, bfacenodes[1, i]] for i in 1:num_sources(bfacenodes)] * gridscale
         c2 = [coord[:, bfacenodes[2, i]] for i in 1:num_sources(bfacenodes)] * gridscale
@@ -338,8 +338,8 @@ function gridplot!(ctx, TP::Type{T}, ::Type{Val{3}}, grid) where {T <: AbstractP
     ax.set_zlim3d(xyzmin[3], xyzmax[3])
     ax.view_init(ctx[:elev], ctx[:azim])
 
-    cmap = region_cmap(max(nregions, 5))
-    bcmap = bregion_cmap(max(nbregions, 5))
+    cmap = ctx[:cellregioncolormap](max(nregions, 5))
+    bcmap = ctx[:bregioncolormap](max(nbregions, 5))
 
     xyzcut = [ctx[:xplanes][1], ctx[:yplanes][1], ctx[:zplanes][1]]
 


### PR DESCRIPTION
One use case I have run into several times now is the need to customize cell and boundary region colormaps for the `gridplot` call.

Since I didn't see any way to make this happen so far, I would propose adding new default keyword arguments and alter the `gridplot` routines so they don't use the hard-coded colormap from `GridVisualizeTools.jl`.

I also altered the 2d `gridplot` example in the docs to showcase this capability to the user.