### PR TITLE
PyPlotter: use increasing figure numbers in initialize!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [1.17.1] - 2026-03-25
+- `PyPlot/PythonPlot`: assign increasing `fignumber`s to each new context (user can see multiple plotting windows)
+
 ## [1.17.0] - 2026-01-09
 - Add `:symlog` axis scaling for symmetric logarithmic axis scaling, see, e.g. [matplotlib symlog](https://matplotlib.org/stable/gallery/scales/symlog_demo.html)
 - Add `:symlog_threshold` (default = 10.0) to determine when to switch from linear to log scaling in case of `:symlog` scaling

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GridVisualize"
 uuid = "5eed8a63-0fb0-45eb-886d-8d5a387d12b8"
 authors = ["Juergen Fuhrmann <juergen.fuhrmann@wias-berlin.de>", "Patrick Jaap <patrick.jaap@wias-berlin.de>"]
-version = "1.17.0"
+version = "1.17.1"
 
 [deps]
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"

--- a/src/dispatch.jl
+++ b/src/dispatch.jl
@@ -337,7 +337,7 @@ function default_plot_kwargs()
         :dim => Pair(1, "Data dimension for PlutoVista plot"),
         :elev => Pair(30, "3D elevation angle  (in degrees)"),
         :elevation => Pair(0.0, "2D plot height factor for elevation"),
-        :fignumber => Pair(1, "Figure number (PyPlot)"),
+        :fignumber => Pair(nothing, "Figure number (PyPlot)"),
         :fontsize => Pair(20, "Fontsize of titles. All others are relative to it"),
         :framepos => Pair(1, "Subplot position in frame (VTKView)"),
         :gridscale => Pair(1, "Grid scale factor. Will be applied also to planes, spacing"),

--- a/src/pycommon.jl
+++ b/src/pycommon.jl
@@ -3,6 +3,10 @@ function initialize!(p, ::Type{T}) where {T <: AbstractPythonPlotterType}
     PyPlotter.rc("font"; size = p.context[:fontsize])
     if !haskey(p.context, :figure)
         res = p.context[:size]
+        if isnothing(p.context[:fignumber])
+            # assign next available figure number if nothing is defined
+            p.context[:fignumber] = isempty(PyPlotter.get_fignums()) ? 1 : maximum(PyPlotter.get_fignums()) + 1
+        end
         if !isdefined(Main, :PlutoRunner)
             p.context[:figure] = PyPlotter.figure(p.context[:fignumber]; dpi = 50, figsize = res ./ 50)
         else


### PR DESCRIPTION
Probably related to https://github.com/WIAS-PDELib/ChargeTransport.jl/issues/114

This enables the user to mix hard-coded `PyPlot`s and the new `ChargeTransport` plotting routines in one session.

Previously, each independent `GridVisualizer` reused the same figure number and did not create a separate window.