### PR TITLE
Add colorbar for cell regions in 2D `gridplot!` with `Py[thon]Plot`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.18.1] - 2026-04-21
+## [1.18.2] - 2026-04-21
 - Add colorbar for cell regions in 2D `gridplot!` with `Py[thon]Plot`
 
 ## [1.18.0] - 2026-04-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [1.18.1] - 2026-04-21
+- Add colorbar for cell regions in 2D `gridplot!` with `Py[thon]Plot`
+
 ## [1.18.0] - 2026-04-15
 - new UnicodePlots.jl extension that at the moment supports gridplot and scalarplot in 1D and 2D
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GridVisualize"
 uuid = "5eed8a63-0fb0-45eb-886d-8d5a387d12b8"
 authors = ["Juergen Fuhrmann <juergen.fuhrmann@wias-berlin.de>", "Patrick Jaap <patrick.jaap@wias-berlin.de>"]
-version = "1.18.1"
+version = "1.18.2"
 
 [deps]
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"

--- a/src/pycommon.jl
+++ b/src/pycommon.jl
@@ -274,41 +274,19 @@ function gridplot!(ctx, TP::Type{T}, ::Type{Val{2}}, grid) where {T <: AbstractP
     )
 
     if ctx[:show_colorbar]
-        if ctx[:colorbar] == :horizontal
-
+        if ctx[:colorbar] in (:horizontal, :vertical)
             fig.colorbar(
                 bcdata;
                 ax = ax,
-                ticks = collect(1:length(bcmap)),
-                orientation = "horizontal",
+                ticks = 1:length(bcmap),
+                orientation = "$(ctx[:colorbar])",
                 label = "boundary regions"
             )
-
             fig.colorbar(
                 cdata;
                 ax = ax,
-                ticks = collect(1:length(cmap)),
-                orientation = "horizontal",
-                label = "cell regions"
-            )
-
-        end
-
-        if ctx[:colorbar] == :vertical
-
-            fig.colorbar(
-                bcdata;
-                ax = ax,
-                ticks = collect(1:length(bcmap)),
-                orientation = "vertical",
-                label = "boundary regions"
-            )
-
-            fig.colorbar(
-                cdata;
-                ax = ax,
-                ticks = collect(1:length(cmap)),
-                orientation = "vertical",
+                ticks = 1:length(cmap),
+                orientation = "$(ctx[:colorbar])",
                 label = "cell regions"
             )
         end

--- a/src/pycommon.jl
+++ b/src/pycommon.jl
@@ -258,6 +258,15 @@ function gridplot!(ctx, TP::Type{T}, ::Type{Val{2}}, grid) where {T <: AbstractP
         vmax = length(bcmap) + 0.5,
     )
 
+    # dummy plot to get a correct color bar for the cell data
+    cdata = ax.tripcolor(
+        dummy_coords_x, dummy_coords_y, dummy_triangle; # use the dummy triangle
+        facecolors = cell_colors[1:1],                  # only one triangle!
+        cmap = PyPlotter.ColorMap(cmap, length(cmap)),
+        vmin = 0.5,
+        vmax = length(cmap) + 0.5,
+    )
+
     ax.tripcolor(
         tridat...;
         facecolors = cell_colors,
@@ -266,22 +275,41 @@ function gridplot!(ctx, TP::Type{T}, ::Type{Val{2}}, grid) where {T <: AbstractP
 
     if ctx[:show_colorbar]
         if ctx[:colorbar] == :horizontal
-            cbar = fig.colorbar(
+
+            fig.colorbar(
                 bcdata;
                 ax = ax,
                 ticks = collect(1:length(bcmap)),
                 orientation = "horizontal",
-                label = "boundary regions",
+                label = "boundary regions"
             )
+
+            fig.colorbar(
+                cdata;
+                ax = ax,
+                ticks = collect(1:length(cmap)),
+                orientation = "horizontal",
+                label = "cell regions"
+            )
+
         end
 
         if ctx[:colorbar] == :vertical
-            cbar = fig.colorbar(
+
+            fig.colorbar(
                 bcdata;
                 ax = ax,
                 ticks = collect(1:length(bcmap)),
                 orientation = "vertical",
-                label = "boundary regions",
+                label = "boundary regions"
+            )
+
+            fig.colorbar(
+                cdata;
+                ax = ax,
+                ticks = collect(1:length(cmap)),
+                orientation = "vertical",
+                label = "cell regions"
             )
         end
     end


### PR DESCRIPTION
I noticed that, in addition to the colorbar for boundary regions, a colorbar for cell regions was missing for 2D gridplots when using the PyPlot/ PythonPlot backend. This PR adds the missing colorbar within the `gridplot!` function.