### PR TITLE
Single indexing of GridVisualizer + show multiple UnicodePlots without Term

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.20.0] - 2026-04-30
+- a `GridVisualizer` can now be indexed with a single index
+- `UnicodePlots`: multiple plots are now displayed even without `Term` loaded, but only one by one
+
 ## [1.19.1] - 2026-04-27
 - several small fixes in `UnicodePlots` extension.
 - fix in slice plotting: use `simplexgrid` constructor for the resulting grid to ensure a consistent grid.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GridVisualize"
 uuid = "5eed8a63-0fb0-45eb-886d-8d5a387d12b8"
-version = "1.19.2"
+version = "1.20.0"
 authors = ["Juergen Fuhrmann <juergen.fuhrmann@wias-berlin.de>", "Patrick Jaap <patrick.jaap@wias-berlin.de>"]
 
 [deps]

--- a/ext/GridVisualizeUnicodePlotsExt.jl
+++ b/ext/GridVisualizeUnicodePlotsExt.jl
@@ -1,6 +1,6 @@
 """
     module GridVisualizeUnicodePlotsExt
-    
+
 Extension module for UnicodePlots.jl
 """
 module GridVisualizeUnicodePlotsExt
@@ -24,7 +24,12 @@ function reveal(p::GridVisualizer, TP::Type{UnicodePlotsType})
         display(subplots[1][:figure])
     else
         if :Term ∉ Symbol.(Base.loaded_modules_array())
-            @warn "A GridVisualizer with multiple UnicodePlots requires 'Term.jl' to be loaded: add Term.jl to your environment."
+            @warn "A GridVisualizer with multiple UnicodePlots can only respect the desired layout if 'Term.jl' is loaded: add Term.jl to your environment and use it."
+
+            # plot figures one by one
+            for subplot in subplots
+                haskey(subplot, :figure) && display(subplot[:figure])
+            end
         else
             # set missing figures
             for subplot in subplots

--- a/src/dispatch.jl
+++ b/src/dispatch.jl
@@ -314,7 +314,7 @@ $(SIGNATURES)
 
 Return a SubVisualizer
 """
-Base.getindex(p::GridVisualizer, i, j) = p.subplots[i, j]
+Base.getindex(p::GridVisualizer, i...) = p.subplots[i...]
 
 """
 $(SIGNATURES)


### PR DESCRIPTION
@j-fu is it ok to have a variable indexing for the gridvisualizer or should we add a method with precisely one index?