### PR TITLE
UnicodePlots: fix grid rescaling issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [1.20.1] -
+- `UnicodePlots`: fixed a grid rescaling issue
+
 ## [1.20.0] - 2026-04-30
 - a `GridVisualizer` can now be indexed with a single index
 - `UnicodePlots`: multiple plots are now displayed even without `Term` loaded, but only one by one

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GridVisualize"
 uuid = "5eed8a63-0fb0-45eb-886d-8d5a387d12b8"
-version = "1.20.0"
+version = "1.20.1"
 authors = ["Juergen Fuhrmann <juergen.fuhrmann@wias-berlin.de>", "Patrick Jaap <patrick.jaap@wias-berlin.de>"]
 
 [deps]

--- a/ext/GridVisualizeUnicodePlotsExt.jl
+++ b/ext/GridVisualizeUnicodePlotsExt.jl
@@ -94,6 +94,11 @@ function gridplot!(ctx, TP::Type{UnicodePlotsType}, ::Type{Val{2}}, grid)
     resolution = ctx[:size] ./ (48, 24) ./ (layout[2], layout[1])
     aspect = ctx[:aspect]
 
+    # ensure that legend fits
+    ncellregions = num_cellregions(grid)
+    nbregions = num_bfaceregions(grid)
+    resolution = (resolution[1], max(resolution[2], 5 + ncellregions + nbregions))
+
     # rescale resolution
     wx = ex[2] - ex[1]
     wy = ey[2] - ey[1]
@@ -102,11 +107,6 @@ function gridplot!(ctx, TP::Type{UnicodePlotsType}, ::Type{Val{2}}, grid)
 
     # we need an integer resolution
     resolution = @. Int(round(resolution))
-
-    # ensure that legend fits
-    ncellregions = num_cellregions(grid)
-    nbregions = num_bfaceregions(grid)
-    resolution = (resolution[1], max(resolution[2], 5 + ncellregions + nbregions))
 
     # create UnicodePlots.Canvas
     CanvasType = UnicodePlots.BrailleCanvas # should this be a changeable parameter ?


### PR DESCRIPTION
First adapt the resolution, then rescale.
Otherwise, small plots have deformed grids.